### PR TITLE
Added in Legacy Node Options Configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-options="--openssl-legacy-provider"


### PR DESCRIPTION
Legacy node options set to allow code to be compiled in recent node versions (i.e. v18.16.1)